### PR TITLE
NM-153: Clean up old reports from Gdrive

### DIFF
--- a/common/src/main/java/gov/nih/nci/evs/cdisc/report/model/ReportSummary.java
+++ b/common/src/main/java/gov/nih/nci/evs/cdisc/report/model/ReportSummary.java
@@ -11,4 +11,5 @@ public class ReportSummary {
     private List<ReportDetail> reportDetails;
     private String publicationDate;
     private List<String> deliveryEmailAddresses;
+    private Integer deleteOldReportsThresholdDays;
 }

--- a/terraform/modules/lambda-container-image/main.tf
+++ b/terraform/modules/lambda-container-image/main.tf
@@ -61,11 +61,15 @@ module "lambda_container_image" {
   policies                     = local.policies
 }
 
-resource "docker_registry_image" "this" {
+resource "docker_image" "this" {
   name = format("%s:%s", data.aws_ecr_repository.ecr_repo.repository_url, local.image_tag)
   build {
-    context    = var.source_path
+    path    = var.source_path
     dockerfile = var.docker_file_path
   }
-  keep_remotely = true
+}
+
+resource "docker_registry_image" "this" {
+  name = docker_image.this.name
+  depends_on = [docker_image.this]
 }

--- a/upload-reports/src/main/java/gov/nih/nci/evs/cdisc/report/UploadReportsService.java
+++ b/upload-reports/src/main/java/gov/nih/nci/evs/cdisc/report/UploadReportsService.java
@@ -63,4 +63,7 @@ public class UploadReportsService {
       }
     }
   }
+  public void deleteOldReports(Integer deleteOldReportsThresholdDays){
+    googleDriveClient.deleteOldFolders(deleteOldReportsThresholdDays);
+  }
 }

--- a/upload-reports/src/main/java/gov/nih/nci/evs/cdisc/report/aws/LambdaHandler.java
+++ b/upload-reports/src/main/java/gov/nih/nci/evs/cdisc/report/aws/LambdaHandler.java
@@ -15,12 +15,17 @@ public class LambdaHandler implements RequestHandler<ReportSummary, ReportSummar
 
   @Override
   public ReportSummary handleRequest(ReportSummary input, Context context) {
-    validate(input);
     GoogleDriveClient googleDriveClient =
         new GoogleDriveClient(SecretsClient.getSecret("/nci/cdisc/gdrive"));
     UploadReportsService service = new UploadReportsService(googleDriveClient);
-    service.uploadReportsFolder(input.getDeliveryEmailAddresses());
-    return input;
+    if (input.getDeleteOldReportsThresholdDays() == null) {
+      validate(input);
+      service.uploadReportsFolder(input.getDeliveryEmailAddresses());
+      return input;
+    } else {
+      service.deleteOldReports(input.getDeleteOldReportsThresholdDays());
+      return input;
+    }
   }
 
   private void validate(ReportSummary request) {


### PR DESCRIPTION
Added a parameter to the upload lambda to delete old reports
Also switched to using both docker_image and docker_registry_image instead of just docker_registry_image (NM-154)