### PR TITLE
NM-155: Get version for docker tag from gradle

### DIFF
--- a/changes-report/build.gradle
+++ b/changes-report/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.4.0'
 
 repositories {
     mavenCentral()

--- a/excel-formatting/build.gradle
+++ b/excel-formatting/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.12.0'
 
 repositories {
     mavenCentral()

--- a/html-report/build.gradle
+++ b/html-report/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.3.0'
 
 repositories {
     mavenCentral()

--- a/odm-report/build.gradle
+++ b/odm-report/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.3.0'
 
 repositories {
     mavenCentral()

--- a/owl-report/build.gradle
+++ b/owl-report/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.4.0'
 
 repositories {
     mavenCentral()

--- a/pairing-report/build.gradle
+++ b/pairing-report/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.4.0'
 
 repositories {
     mavenCentral()

--- a/pdf-report/build.gradle
+++ b/pdf-report/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.10.0'
 
 repositories {
     mavenCentral()

--- a/post-process-reports/build.gradle
+++ b/post-process-reports/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.2.0'
 
 repositories {
     mavenCentral()

--- a/scripts/get-gradle-version.sh
+++ b/scripts/get-gradle-version.sh
@@ -1,0 +1,25 @@
+# This script is used in the terraform external datasource. So the input is based on the standard JSON input prescribed by that resource.
+
+# Serialize the input JSON as space separated values. For example {"key1":"value1","key2":"values2"} will turn into "key1 value1 key2 value2"
+input_string=$(jq -M -r 'keys[] as $k | $k, .[$k]')
+
+# Convert space separated values into array
+input_array=(${input_string})
+output="{"
+# iterate through the array 2 elements at a time to capture the key and value
+for ((i = 0; i < ${#input_array}; i += 2)); do
+  # determine the version of the module from gradle build
+  version=$(
+    cd "${input_array[$i + 1]}"
+    gradle properties -q | grep "version:" | awk '{print $2}'
+  )
+  # use the key that was passed and set the value as the version that was determined
+  output+="\"${input_array[$i]}\":\"$version\""
+  if [[ $i+2 -lt ${#input_array} ]]; then
+    output+=","
+  fi
+done
+output+='}'
+
+# Use jq to turn the output string into JSON
+jq -n $output

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,12 +13,28 @@ locals {
   upload_report_configuration               = local.lambda_configuration["cdisc-upload-report"]
 }
 
+data external "versions"{
+  program = ["bash", "../scripts/get-gradle-version.sh"]
+  query = {
+    "cdisc-text-excel-report-generator" = "../text-excel-reports"
+    "cdisc-pairing-report-generator" = "../pairing-report"
+    "cdisc-excel-report-formatter" = "../excel-formatting"
+    "cdisc-changes-report-generator" = "../changes-report"
+    "cdisc-odm-xml-report-generator" = "../odm-report"
+    "cdisc-html-report-generator" = "../html-report"
+    "cdisc-pdf-report-generator" = "../pdf-report"
+    "cdisc-owl-report-generator" = "../owl-report"
+    "cdisc-post-process-report" = "../post-process-reports"
+    "cdisc-upload-report" = "../upload-reports"
+  }
+}
+
 module "text_excel_report_generator_lambda" {
   source                       = "./modules/lambda-container-image"
   architecture                 = var.architecture
   function_name                = "cdisc-text-excel-report-generator"
   description                  = "Lambda that creates text and excel files from Thesaurus owl file for a specific concept"
-  image_version                = local.text_excel_report_generator_configuration.version
+  image_version                = data.external.versions.result.cdisc-text-excel-report-generator
   source_path                  = "../text-excel-reports"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.text_excel_report_generator_configuration.timeout_in_mins * 60
@@ -35,7 +51,7 @@ module "pairing_report_generator_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-pairing-report-generator"
   description                  = "Lambda that creates pairing reports"
-  image_version                = local.pairing_report_generator_configuration.version
+  image_version                = data.external.versions.result.cdisc-pairing-report-generator
   source_path                  = "../pairing-report"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.pairing_report_generator_configuration.timeout_in_mins * 60
@@ -52,7 +68,7 @@ module "excel_report_formatter_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-excel-report-formatter"
   description                  = "Lambda that formats excel reports created by cdisc-text-excel-report-generator"
-  image_version                = local.excel_report_formatter_configuration.version
+  image_version                = data.external.versions.result.cdisc-excel-report-formatter
   source_path                  = "../excel-formatting"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.excel_report_formatter_configuration.timeout_in_mins * 60
@@ -69,7 +85,7 @@ module "changes_report_generator_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-changes-report-generator"
   description                  = "Lambda that creates a report detailing the differences between the current and previous text report"
-  image_version                = local.changes_report_generator_configuration.version
+  image_version                = data.external.versions.result.cdisc-changes-report-generator
   source_path                  = "../changes-report"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.changes_report_generator_configuration.timeout_in_mins * 60
@@ -86,7 +102,7 @@ module "odm_xml_report_generator_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-odm-xml-report-generator"
   description                  = "Lambda that creates odm xml"
-  image_version                = local.odm_xml_report_generator_configuration.version
+  image_version                = data.external.versions.result.cdisc-odm-xml-report-generator
   source_path                  = "../odm-report"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.odm_xml_report_generator_configuration.timeout_in_mins * 60
@@ -103,7 +119,7 @@ module "html_report_generator_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-html-report-generator"
   description                  = "Lambda that creates two HTML reports from the XML file created in cdisc-odm-xml-report-generator. One of the HTML files is the HTML report. The other file is a HTML file from which a PDF file will be generated in a subsequent step"
-  image_version                = local.html_report_generator_configuration.version
+  image_version                = data.external.versions.result.cdisc-html-report-generator
   source_path                  = "../html-report"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.html_report_generator_configuration.timeout_in_mins * 60
@@ -120,7 +136,7 @@ module "pdf_report_generator_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-pdf-report-generator"
   description                  = "Lambda to create a PDF report from a HMTL file created by cdisc-html-report-generator"
-  image_version                = local.pdf_report_generator_configuration.version
+  image_version                = data.external.versions.result.cdisc-pdf-report-generator
   source_path                  = "../pdf-report"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.pdf_report_generator_configuration.timeout_in_mins * 60
@@ -137,7 +153,7 @@ module "owl_report_generator_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-owl-report-generator"
   description                  = "Lambda to create a OWL file from the text file created by cdisc-text-excel-report-generator"
-  image_version                = local.owl_report_generator_configuration.version
+  image_version                = data.external.versions.result.cdisc-owl-report-generator
   source_path                  = "../owl-report"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.owl_report_generator_configuration.timeout_in_mins * 60
@@ -154,7 +170,7 @@ module "post_process_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-post-process-reports"
   description                  = "Lambda to consolidate reports outputs and package reports"
-  image_version                = local.post_process_report_configuration.version
+  image_version                = data.external.versions.result.cdisc-post-process-report
   source_path                  = "../post-process-reports"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.post_process_report_configuration.timeout_in_mins * 60
@@ -171,7 +187,7 @@ module "upload_report_lambda" {
   architecture                 = var.architecture
   function_name                = "cdisc-upload-report"
   description                  = "Lambda that uploads all generated reports to GDrive"
-  image_version                = local.upload_report_configuration.version
+  image_version                = data.external.versions.result.cdisc-upload-report
   source_path                  = "../upload-reports"
   docker_file_path             = "./Dockerfile"
   timeout_in_seconds           = local.upload_report_configuration.timeout_in_mins * 60

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -219,16 +219,3 @@ provider "docker" {
 data "aws_ecr_repository" "main_ecr_repo" {
   name = "cdisc-report-generators"
 }
-
-resource "docker_image" "this" {
-  name = format("%s:%s", data.aws_ecr_repository.main_ecr_repo.repository_url, "test-image")
-  build {
-    path                  = "../upload-reports"
-    dockerfile             = "./Dockerfile"
-  }
-}
-
-resource "docker_registry_image" "this" {
-  name = docker_image.this.name
-  depends_on = [docker_image.this]
-}

--- a/terraform/modules/lambda-container-image/main.tf
+++ b/terraform/modules/lambda-container-image/main.tf
@@ -11,14 +11,6 @@ terraform {
   }
 }
 
-provider "docker" {
-  registry_auth {
-    address  = split("/", data.aws_ecr_repository.ecr_repo.repository_url)[0]
-    username = data.aws_ecr_authorization_token.token.user_name
-    password = data.aws_ecr_authorization_token.token.password
-  }
-}
-
 data "aws_region" "current" {
 
 }

--- a/terraform/modules/lambda-container-image/main.tf
+++ b/terraform/modules/lambda-container-image/main.tf
@@ -22,10 +22,6 @@ data "aws_ecr_repository" "ecr_repo" {
   name = "cdisc-report-generators"
 }
 
-data "aws_ecr_authorization_token" "token" {
-
-}
-
 locals {
   image_tag = format("%s-%s", var.function_name, var.image_version)
   policies  = concat(var.policies, ["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"])

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,7 +35,7 @@ variable "architecture" {
 }
 
 variable "lambda_configuration" {
-  type = map(object({ version = string, memory_in_mb = optional(number), timeout_in_mins = optional(number) }))
+  type = map(object({ memory_in_mb = optional(number), timeout_in_mins = optional(number) }))
 }
 
 variable "file_system_local_mount_path" {

--- a/text-excel-reports/build.gradle
+++ b/text-excel-reports/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.23.0'
 
 dependencies {
     implementation 'gov.nih.nci.evs.reportwriter.core:reportwriter-core:1.0.9-SNAPSHOT'

--- a/upload-reports/build.gradle
+++ b/upload-reports/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '1.0'
+version '0.2.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Added get-gradle-version.sh script to determine the gradle version instead of having the version specified in 2 places namely the gradle.build file and the terraform variable file