### PR TITLE
NM-157: Get CDISC dependencies from Nexus

### DIFF
--- a/buildSrc/src/main/groovy/parent.gradle
+++ b/buildSrc/src/main/groovy/parent.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'java-library'
+    id 'maven-publish'
 }
 
 java {
@@ -14,6 +15,24 @@ version '1.0'
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        name 'nexus'
+        url 'https://ncimvn.nci.nih.gov/nexus/content/repositories/EVSReleases'
+        // Credentials are supplied through the local gradle properties file. Usually located at <HOME>/.gradle/gradle.properties
+        credentials {
+            username nexusUsername
+            password nexusPassword
+        }
+    }
+    maven {
+        name 'nexus-snapshots'
+        url 'https://ncimvn.nci.nih.gov/nexus/content/repositories/EVSSnapshots'
+        // Credentials are supplied through the local gradle properties file. Usually located at <HOME>/.gradle/gradle.properties
+        credentials {
+            username nexusUsername
+            password nexusPassword
+        }
+    }
 }
 
 dependencies {

--- a/text-excel-reports/build.gradle
+++ b/text-excel-reports/build.gradle
@@ -2,12 +2,45 @@ plugins {
     id 'parent'
 }
 
+group 'gov.nih.nci.evs.cdisc'
 version '0.23.0'
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId 'text-excel-reports'
+            artifact("build/libs/$project.name-$version" + ".jar") {
+                extension 'jar'
+            }
+        }
+
+    }
+    repositories {
+        maven {
+            name 'nexus'
+            url 'https://ncimvn.nci.nih.gov/nexus/content/repositories/EVSReleases'
+            credentials {
+                username nexusUsername
+                password nexusPassword
+            }
+        }
+        maven {
+            name 'nexus-snapshots'
+            url 'https://ncimvn.nci.nih.gov/nexus/content/repositories/EVSSnapshots'
+            credentials {
+                username nexusUsername
+                password nexusPassword
+            }
+        }
+    }
+}
+
 
 dependencies {
     implementation 'gov.nih.nci.evs.reportwriter.core:reportwriter-core:1.0.9-SNAPSHOT'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-runtime-interface-client:1.0.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-1.2-api:2.17.2'
     implementation project(':common')
 
     testImplementation project(":common").sourceSets.test.output


### PR DESCRIPTION
Added pulling from and pushing to Nexus repo. For pushing, just added it to the text-excel-reports module as an example. We dont really have a need to push to Nexus at the moment.