### PR TITLE
NM-179: Remove experimental feature that is used in terraform for CDI…

### DIFF
--- a/post-process-reports/build.gradle
+++ b/post-process-reports/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '0.2.0'
+version '0.3.0'
 
 repositories {
     mavenCentral()

--- a/post-process-reports/src/main/java/gov/nih/nci/evs/cdisc/report/PostProcessService.java
+++ b/post-process-reports/src/main/java/gov/nih/nci/evs/cdisc/report/PostProcessService.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class PostProcessService {
     }
     Path archiveFilePath = getArchiveFilePath(reportFile, publicationDate);
     try {
-      Files.copy(Path.of(reportFile), archiveFilePath);
+      Files.copy(Path.of(reportFile), archiveFilePath, StandardCopyOption.REPLACE_EXISTING);
     } catch (IOException e) {
       throw new RuntimeException(
           String.format(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,16 +1,14 @@
 locals {
-  lambda_configuration = defaults(var.lambda_configuration, { memory_in_mb = 1024
-  timeout_in_mins = 5 })
-  text_excel_report_generator_configuration = local.lambda_configuration["cdisc-text-excel-report-generator"]
-  pairing_report_generator_configuration    = local.lambda_configuration["cdisc-pairing-report-generator"]
-  excel_report_formatter_configuration      = local.lambda_configuration["cdisc-excel-report-formatter"]
-  changes_report_generator_configuration    = local.lambda_configuration["cdisc-changes-report-generator"]
-  odm_xml_report_generator_configuration    = local.lambda_configuration["cdisc-odm-xml-report-generator"]
-  html_report_generator_configuration       = local.lambda_configuration["cdisc-html-report-generator"]
-  pdf_report_generator_configuration        = local.lambda_configuration["cdisc-pdf-report-generator"]
-  owl_report_generator_configuration        = local.lambda_configuration["cdisc-owl-report-generator"]
-  post_process_report_configuration         = local.lambda_configuration["cdisc-post-process-report"]
-  upload_report_configuration               = local.lambda_configuration["cdisc-upload-report"]
+  text_excel_report_generator_configuration = var.lambda_configuration["cdisc-text-excel-report-generator"]
+  pairing_report_generator_configuration    = var.lambda_configuration["cdisc-pairing-report-generator"]
+  excel_report_formatter_configuration      = var.lambda_configuration["cdisc-excel-report-formatter"]
+  changes_report_generator_configuration    = var.lambda_configuration["cdisc-changes-report-generator"]
+  odm_xml_report_generator_configuration    = var.lambda_configuration["cdisc-odm-xml-report-generator"]
+  html_report_generator_configuration       = var.lambda_configuration["cdisc-html-report-generator"]
+  pdf_report_generator_configuration        = var.lambda_configuration["cdisc-pdf-report-generator"]
+  owl_report_generator_configuration        = var.lambda_configuration["cdisc-owl-report-generator"]
+  post_process_report_configuration         = var.lambda_configuration["cdisc-post-process-report"]
+  upload_report_configuration               = var.lambda_configuration["cdisc-upload-report"]
 }
 
 data "external" "versions" {

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,5 +1,4 @@
 terraform {
-  experiments = [module_variable_optional_attrs]
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"
@@ -7,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "4.16.0"
+      version = ">=4.16.0"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,7 +35,10 @@ variable "architecture" {
 }
 
 variable "lambda_configuration" {
-  type = map(object({ memory_in_mb = optional(number), timeout_in_mins = optional(number) }))
+  type = map(object({
+    memory_in_mb = optional(number, 1024),
+    timeout_in_mins = optional(number, 5)
+  }))
 }
 
 variable "file_system_local_mount_path" {

--- a/upload-reports/build.gradle
+++ b/upload-reports/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'parent'
 }
 
-version '0.4.0'
+version '0.5.0'
 
 repositories {
     mavenCentral()

--- a/upload-reports/src/main/java/gov/nih/nci/evs/cdisc/report/UploadReportsService.java
+++ b/upload-reports/src/main/java/gov/nih/nci/evs/cdisc/report/UploadReportsService.java
@@ -51,8 +51,8 @@ public class UploadReportsService {
     com.google.api.services.drive.model.File driveTargetFolder =
         googleDriveClient.createFolder(targetFolder, null, "id, webViewLink");
     log.info("Report Upload Folder Id:{} ", driveTargetFolder.getId());
-    googleDriveClient.grantWritePermissions(driveTargetFolder, emailAddresses);
     uploadFolder(sourceFolder.toFile(), driveTargetFolder);
+    googleDriveClient.grantWritePermissions(driveTargetFolder, emailAddresses);
   }
 
   private void uploadFolder(java.io.File folder, File parentFolder) {


### PR DESCRIPTION
1. Removed experimental feature. This feature has been made as a regular feature of Terraform since 1.3.
2. Fixed issue where job would fail on archiving if reports already existed
3. Moved granting of permissions after uploading reports to GDrive
